### PR TITLE
Output CRF should always be 16.

### DIFF
--- a/cmd/client/concat.go
+++ b/cmd/client/concat.go
@@ -144,12 +144,13 @@ func scale(v *Video) bool {
     params := []string{}
     params = append(params, "-i", original)
     params = append(params, "-map", "0:v:0")
-    params = append(params, "-vf", v.Filter(true))
+    // preset group 0 should be scaled to 720p to increase encoding speed.
+    params = append(params, "-vf", v.Filter(GetParameters().PresetGroup() == 0))
     params = append(params, "-vsync", "1")
     params = append(params, "-vcodec", "libx264")
     params = append(params, "-r", v.Fps())
-    // preset group 0 has -crf 16; preset group 1 has -crf 10; preset group 2 has -crf 4.
-    params = append(params, "-crf", strconv.Itoa(16 - GetParameters().PresetGroup() * 6))
+    // preset group 0 has -crf 14; preset group 1 has -crf 10; preset group 2 has -crf 6.
+    params = append(params, "-crf", strconv.Itoa(14 - GetParameters().PresetGroup() * 4))
     params = append(params, "-preset", GetParameters().Preset())
     params = append(params, "-profile:v", "high10")
     params = append(params, "-level:v", "6.1")
@@ -192,8 +193,8 @@ func sanitize(v *Video, fps string, w int, h int, c int, dar float64) bool {
     params = append(params, "-vsync", "1")
     params = append(params, "-vcodec", "libx264")
     params = append(params, "-r", fps)
-    // preset group 0 has -crf 16; preset group 1 has -crf 10; preset group 2 has -crf 4.
-    params = append(params, "-crf", strconv.Itoa(16 - GetParameters().PresetGroup() * 6))
+    // preset group 0 has -crf 14; preset group 1 has -crf 10; preset group 2 has -crf 6.
+    params = append(params, "-crf", strconv.Itoa(14 - GetParameters().PresetGroup() * 4))
     params = append(params, "-preset", GetParameters().Preset())
     params = append(params, "-profile:v", "high10")
     params = append(params, "-level:v", "6.1")

--- a/cmd/client/optimize.go
+++ b/cmd/client/optimize.go
@@ -129,8 +129,7 @@ func optimizeVideo(m *Media) bool {
     params = append(params, "-vsync", "1")
     params = append(params, "-vcodec", GetParameters().VideoCodec())
     params = append(params, "-r", m.Video().Fps())
-    // preset group 0 has -crf 22; preset group 1 has -crf 16; preset group 2 has -crf 10.
-    params = append(params, "-crf", strconv.Itoa(22 - GetParameters().PresetGroup() * 6))
+    params = append(params, "-crf", "16")
     params = append(params, "-maxrate", strconv.Itoa(m.TargetVideoBitrate()))
     params = append(params, "-bufsize", strconv.Itoa(m.TargetVideoBitrate() * 2))
     params = append(params, "-preset", GetParameters().Preset())


### PR DESCRIPTION
Output CRF should always be 16. Concatination CRF range should be
tightned as there is no need for slowest to use a CRF of 4 here.
Concatination scaling should only force 720p when encoding using
a preset of faster or quicker to speed up the concatination process
at a slight visual quality loss. Other presets should wait until
the optimizatuion step to scale the resulting video to 720p.