### PR TITLE
Parallel Process Scenes Instead Of Relying On FFMPEG Multithreading

### DIFF
--- a/cmd/client/concat.go
+++ b/cmd/client/concat.go
@@ -103,7 +103,6 @@ func joinAll(videos []*Video, title string, to string) bool {
     defer os.RemoveAll(tmpFiles)
     Write(filepath.Join(tmpFiles, "files.txt"), files(videos))
     Write(filepath.Join(tmpFiles, "metadata.txt"), metadata(title, videos))
-    fmt.Println("tmpFiles", tmpFiles)
     params := []string{}
     params = append(params, "-f", "concat")
     params = append(params, "-safe", "0")
@@ -255,7 +254,7 @@ func metadata(title string, videos []*Video) string {
     start := 0
     end := 0
     for i, v := range videos {
-        end = end + v.Duration()
+        end = end + v.DurationMs()
         chapterData = chapterData + "[CHAPTER]\n"
         chapterData = chapterData + "TIMEBASE=1/1000\n"
         chapterData = chapterData + fmt.Sprintf("START=%v\n", start)

--- a/cmd/client/media.go
+++ b/cmd/client/media.go
@@ -56,19 +56,19 @@ func (m *Media) Audio() *Audio {
     return m.audio
 }
 
-func (m *Media) TargetAudioBitrate() int {
+func (m *Media) MaxAudioBitrate() int {
     return 90000 + (m.Audio().Channels() - 1) * 12000
 }
 
-func (m *Media) TargetVideoBitrate() int {
-    return GetParameters().Bitrate() - m.TargetAudioBitrate()
+func (m *Media) MaxVideoBitrate() int {
+    return GetParameters().Bitrate() - m.MaxAudioBitrate()
 }
 
 func (m *Media) OptimizedAudio() bool {
     if m.Audio().Bitrate() < 10000 {
         return false
     }
-    if m.Audio().Bitrate() > m.TargetAudioBitrate() + 10000 {
+    if m.Audio().Bitrate() > m.MaxAudioBitrate() + 10000 {
         return false
     }
     return true
@@ -78,7 +78,7 @@ func (m *Media) OptimizedVideo() bool {
     if m.Video().Bitrate() < 500000 {
         return false
     }
-    if m.Video().Bitrate() > m.TargetVideoBitrate() + 40000 {
+    if m.Video().Bitrate() > m.MaxVideoBitrate() + 40000 {
         return false
     }
     if m.Video().Width() > 1280 || m.Video().Height() > 720 {

--- a/cmd/client/optimize.go
+++ b/cmd/client/optimize.go
@@ -7,6 +7,7 @@ import (
     "os/exec"
     "os"
     "strconv"
+    "strings"
 )
 
 func Optimize(m *Media) {
@@ -86,7 +87,7 @@ func optimizeAudio(m *Media) bool {
     params = append(params, "-map", "1:a:0")
     params = append(params, "-c:a", GetParameters().AudioCodec())
     params = append(params, "-filter:a", "aresample=async=1:min_hard_comp=0.100000:first_pts=0")
-    params = append(params, "-ab", strconv.Itoa(m.TargetAudioBitrate()))
+    params = append(params, "-ab", strconv.Itoa(m.MaxAudioBitrate()))
     params = append(params, "-ac", strconv.Itoa(m.Audio().Channels()))
     params = append(params, "-movflags", "+faststart")
     params = append(params, "-f", "mp4")
@@ -112,80 +113,35 @@ func optimizeAudio(m *Media) bool {
 }
 
 func optimizeVideo(m *Media) bool {
-    fmt.Println("Optimize Video:")
-    tmpDir, err := ioutil.TempDir(os.TempDir(), "optimize-")
-    defer os.RemoveAll(tmpDir)
-    if err != nil {
-        fmt.Println(err)
-        return false
+    fmt.Println("Optimizing", m.Name())
+    path := filepath.Join(DefaultMetadataDir(), m.Name())
+    if (!PathExists(path)) {
+        Mkdir(path)
     }
-    original := filepath.Join(tmpDir, "original.mp4")
-    optimized := filepath.Join(tmpDir, "optimized.mp4")
-    Copy(m.Video().Path(), original)
+    defer os.RemoveAll(path)
+    original := &Video{}
+    original.SetPath(filepath.Join(path, "original.mp4"))
+    if !PathExists(original.Path()) {
+        Copy(m.Video().Path(), original.Path())
+    }
+    optimized := filepath.Join(path, "optimized.mp4")
+    original.DetectCrop()
+    scenes := ""
+    for _, scene := range optimizeScenes(path, original, m.MaxVideoBitrate()) {
+        scenes = scenes + fmt.Sprintf("file '%v'\n", scene.Path())
+    }
+    tmpFiles, _ := ioutil.TempDir(os.TempDir(), GetBrand())
+    defer os.RemoveAll(tmpFiles)
+    Write(filepath.Join(tmpFiles, "scenes.txt"), scenes)
     params := []string{}
-    if GetParameters().ForceAv1() {
-        // This may take some tweaking still.
-        // https://www.reddit.com/r/AV1/comments/mxa3vf/first_time_looking_to_encode_in_av1_what_to_use/
-        //
-        // Accordig to https://goughlui.com/2016/08/27/video-compression-testing-x264-vs-x265-crf-in-handbrake-0-10-5/
-        // there’s really no big difference between PSNRs for the average case between x264 and x265 on a CRF value basis.
-
-        // https://engineering.fb.com/2018/04/10/video-engineering/av1-beats-x264-and-libvpx-vp9-in-practical-use-case/
-        // x264 CRF = {19, 23, 27, 31, 35, 39}, VP9/AV1 CRF/QP = {27, 33, 39, 45, 51, 57}
-        // according to the above mapping, an h264 CRF of 16 == AV1 CRF of 22.5
-
-        // https://brontosaurusrex.github.io/2021/06/05/AV1-encoding-for-dummies/
-        // ffmpeg -i "Tears of Steel (2012) copy.webm" -map 0:v:0 -denoise-noise-level 50 -vf format=yuv420p10le,colorspace=bt709:iall=bt2020:fast=1,scale=w=1280:h=720:flags=print_info+spline+full_chroma_inp+full_chroma_int,hqdn3d=1:1:9:9,unsharp=5:5:0.8:3:3:0.4 -vsync 1 -vcodec libaom-av1 -qmin 23 -qmax 63 -b:v 1500000 -maxrate 1848000 -bufsize 3696000 -cpu-used 5 -row-mt true -threads 0 -tile-columns 1 -tile-rows 0 -map 0:a -c:a copy -movflags +faststart -f mp4 -y "Tears of Steel (2012).mp4"
-        params = append(params, "-i", original)
-        params = append(params, "-map", "0:v:0")
-        params = append(params, "-denoise-noise-level", "50")
-        params = append(params, "-vf", m.Video().Filter(true))
-        params = append(params, "-vsync", "1")
-        params = append(params, "-vcodec", "libaom-av1")
-        params = append(params, "-qmin", "23")
-        params = append(params, "-qmax", "63")
-        params = append(params, "-b:v", strconv.Itoa(m.TargetVideoBitrate() - 300000))
-        params = append(params, "-maxrate", strconv.Itoa(m.TargetVideoBitrate()))
-        params = append(params, "-bufsize", strconv.Itoa(m.TargetVideoBitrate() * 2))
-        params = append(params, "-cpu-used", strconv.Itoa(7 - GetParameters().PresetGroup() * 2))
-        params = append(params, "-g", "60")
-        params = append(params, "-keyint_min", "60")
-        params = append(params, "-sc_threshold", "0")
-        params = append(params, "-map", "0:a")
-        params = append(params, "-c:a", "copy")
-        params = append(params, "-movflags", "+faststart")
-        params = append(params, "-f", "mp4")
-        params = append(params, "-y")
-        params = append(params, optimized)
-    } else {
-        params = append(params, "-i", original)
-        params = append(params, "-map", "0:v:0")
-        params = append(params, "-vf", m.Video().Filter(true))
-        params = append(params, "-vsync", "1")
-        params = append(params, "-vcodec", GetParameters().VideoCodec())
-        params = append(params, "-r", m.Video().Fps())
-        params = append(params, "-crf", "16")
-        params = append(params, "-maxrate", strconv.Itoa(m.TargetVideoBitrate()))
-        params = append(params, "-bufsize", strconv.Itoa(m.TargetVideoBitrate() * 2))
-        params = append(params, "-preset", GetParameters().Preset())
-        params = append(params, "-profile:v", GetParameters().VideoProfile())
-        if GetParameters().ForceAvc() {
-            params = append(params, "-level:v", "4.0")
-            params = append(params, "-g", "60")
-            params = append(params, "-sc_threshold", "0")
-        } else {
-            params = append(params, "-x265-params", "level-idc=40:keyint=60:min-keyint=60:scenecut=0")
-        }
-        params = append(params, "-map", "0:a")
-        params = append(params, "-c:a", "copy")
-        params = append(params, "-movflags", "+faststart")
-        params = append(params, "-f", "mp4")
-        params = append(params, "-y")
-        params = append(params, optimized)
-    }
-    PrintFfmpeg(params)
-    fmt.Println("Executing...")
-    err = exec.Command("ffmpeg", params...).Run()
+    params = append(params, "-f", "concat")
+    params = append(params, "-safe", "0")
+    params = append(params, "-i", filepath.Join(tmpFiles, "scenes.txt"))
+    params = append(params, "-c", "copy")
+    params = append(params, optimized)
+    // PrintFfmpeg(params)
+    // fmt.Println("Executing...")
+    err := exec.Command("ffmpeg", params...).Run()
     if err != nil {
         fmt.Println(err)
         return false
@@ -202,4 +158,174 @@ func optimizeVideo(m *Media) bool {
     m.Video().SetPath(m.Path() + m.Name() + ".mp4")
     m.Audio().SetPath(m.Path() + m.Name() + ".mp4")
     return true
+}
+
+func detectScenes(target string, v *Video) {
+    fmt.Println("Detecting Scenes...")
+    detectScenes := []string{}
+    detectScenes = append(detectScenes, "ffprobe")
+    detectScenes = append(detectScenes, "-show_frames")
+    detectScenes = append(detectScenes, "-show_entries", "frame=best_effort_timestamp_time")
+    detectScenes = append(detectScenes, "-of", "compact=p=0")
+    detectScenes = append(detectScenes, "-f", "lavfi", fmt.Sprintf(`"movie=%s,select=gt(scene\,0.5)"`, v.Path()))
+    detectScenes = append(detectScenes, ">", fmt.Sprintf(`"%s"`, target))
+    // fmt.Println(strings.Join(detectScenes, " "))
+    err := exec.Command("bash","-c",strings.Join(detectScenes, " ")).Run()
+    if err != nil {
+        fmt.Println(err)
+    }
+}
+
+func optimizeScenes(path string, v *Video, maxBitrate int) []*Video {
+    detectedScenes := filepath.Join(path, "scenes.txt")
+    if !PathExists(detectedScenes) {
+        detectScenes(detectedScenes, v)
+    }
+    cores := GetParameters().Cores()
+    minDuration := float64(300)
+    if thisDuration, _ := strconv.ParseFloat(v.Duration(), 64); thisDuration / float64(cores) < minDuration {
+        minDuration = thisDuration / float64(cores)
+    }
+    prevTime := float64(0)
+    detectedTimes := make([]string, 0)
+    for _, detectedScene := range Read(detectedScenes) {
+        meta := strings.Split(detectedScene, "|")
+        time := strings.TrimPrefix(meta[0], "best_effort_timestamp_time=")
+        score := strings.TrimPrefix(meta[1], "tag:lavfi.scene_score=")
+        if thisTime, _ := strconv.ParseFloat(time, 64); thisTime - prevTime > minDuration {
+            detectedTimes = append(detectedTimes, time)
+            fmt.Println("scene", len(detectedTimes), time, score)
+            prevTime = thisTime
+        }
+    }
+    detectedTimes = append(detectedTimes, v.Duration())
+    fmt.Println("scene", len(detectedTimes), v.Duration(), "1.000000")
+    // Create a bounded channel, limit that channel to 5 cores.
+    // source: https://medium.com/@deckarep/gos-extended-concurrency-semaphores-part-1-5eeabfa351ce
+    var sem = make(chan int, cores)
+    start := "0"
+    scenes := make([]*Video, 0)
+    for i, end := range detectedTimes {
+        scene := Video{}
+        scene.SetPath(v.Path() + ".pt" + strconv.Itoa(i))
+        scenes = append(scenes, &scene)
+        sem <- 1
+        go func(v *Video, start string, end string, i int) {
+            optimizeScene(v, maxBitrate, start, end, i)
+            <-sem
+        }(v, start, end, i)
+        start = end
+    }
+    // Fill the bounded channel up which forces us to block until all threads have finished.
+    for i := 0; i < cores; i++ {
+        sem <- 1
+    }
+    // Clear the bounded channel. Probably not needed.
+    for i := 0; i < cores; i++ {
+        <-sem
+    }
+    return scenes
+}
+
+func optimizeScene(v *Video, maxBitrate int, start string, end string, count int) {
+    if PathExists(v.Path() + ".pt" + strconv.Itoa(count)) {
+        return
+    }
+    fmt.Println("Optimizing scene: ", start, end, count)
+    startEstimate, _ := strconv.ParseFloat(start, 64)
+    startEstimate = startEstimate - float64(3)
+    params := []string{}
+    // https://stackoverflow.com/questions/21420296/how-to-extract-time-accurate-video-segments-with-ffmpeg
+    // Just supplying the -ss and -to parameters before the input value to enable keyframe seeking 
+    // should be fince since we are obtaining the times to split on by finding keyframes with large
+    // amounts change from the previous frame.
+    params = append(params, "-ss", start)
+    params = append(params, "-to", end)
+    params = append(params, "-i", v.Path())
+    params = append(params, "-map", "0:v:0")
+    if GetParameters().ForceAv1() {
+        // https://brontosaurusrex.github.io/2021/06/05/AV1-encoding-for-dummies/
+        // Setting the denoise-noise-level parameter enables grain synthesis.
+        // This needs to be set before the video filter because the video filter does scaling 
+        // and we want to denoise the video before scaling the video.
+        params = append(params, "-denoise-noise-level", "50")
+    }
+    // Add video filters such as scaling, denoising, and deinterlacing.
+    params = append(params, "-vf", v.Filter(true))
+    // Setting vsync to 1 forces a constant frame rate.
+    params = append(params, "-vsync", "1")
+    // Limit threads here; we are using parallel processing of multiple scenes instead of 
+    // ffmpeg's native multithreading. This is needed because a lot of the video filters 
+    // are slow because they are not multi-threaded.
+    params = append(params, "-threads", "1")
+    params = append(params, "-vcodec", GetParameters().VideoCodec())
+    params = append(params, "-r", v.Fps())
+    if GetParameters().ForceAv1() {
+        // Setting the lag-in-frames to 25 lets the AV1 codec look ahead 25 frames into the future.
+        // Higher values improve visual quality.
+        params = append(params, "-lag-in-frames", "25")
+        // Enable use of alternate reference frames.
+        params = append(params, "-auto-alt-ref", "1")
+        // https://engineering.fb.com/2018/04/10/video-engineering/av1-beats-x264-and-libvpx-vp9-in-practical-use-case/
+        // x264 CRF = {19, 23, 27, 31, 35, 39}, VP9/AV1 CRF/QP = {27, 33, 39, 45, 51, 57}
+        // according to the above mapping, an h264 CRF of 16 == AV1 CRF of 22.5
+        // Do not try for a better quality than 23; doing throw is wasting bits on diminishing 
+        // returns as a qmin of 23 for the AV1 codec is already considered visually lossless.
+        params = append(params, "-qmin", "23")
+        // Do not limit the worst case visual quality scenario as this will be capped by the max 
+        // bitrate.
+        params = append(params, "-qmax", "63")
+        // Set the quality/encoding speed tradeoff. Valid range is from 0 to 8, higher numbers 
+        // indicating greater speed and lower quality.
+        // * Presets of ultrafast to faster use a value of 7.
+        // * Presets of fast to slow use a value of 4.
+        // * presets of slower to placebo use a value of 1.
+        params = append(params, "-cpu-used", strconv.Itoa(7 - GetParameters().PresetGroup() * 3))
+        // Set the max frames between keyframes
+        params = append(params, "-g", GetParameters().GOP())
+        // Set average bitrate to be 200kbps less than the max bitrate.
+        params = append(params, "-b:v", strconv.Itoa(maxBitrate - 200000))
+    } else {
+        // Accordig to https://goughlui.com/2016/08/27/video-compression-testing-x264-vs-x265-crf-in-handbrake-0-10-5/
+        // there’s really no big difference between PSNRs for the average case between x264 and x265 on a CRF value basis.
+        params = append(params, "-crf", "16")
+        params = append(params, "-preset", GetParameters().Preset())
+        params = append(params, "-profile:v", GetParameters().VideoProfile())
+        if GetParameters().ForceAvc() {
+            // Set the video level to 4.0 as its a good balance between compatability and quality.
+            params = append(params, "-level:v", "4.0")
+            // Set the max frames between keyframes.
+            params = append(params, "-g", GetParameters().GOP())
+        } else if GetParameters().ForceHevc() {
+            h265Params := []string{}
+            // Set the video level to 4.0 as its a good balance between compatability and quality.
+            h265Params = append(h265Params, "level-idc=40")
+            // Set the max frames between keyframes.
+            h265Params = append(h265Params, "keyint=" + GetParameters().GOP())
+            // These values need to be supplied to the x265 codec directly.
+            params = append(params, "-x265-params", strings.Join(h265Params, ":"))
+        }
+    }
+    // Setting the maxrate parameter caps the maximum bitrate.
+    params = append(params, "-maxrate", strconv.Itoa(maxBitrate))
+    // Cap max buffer size to twice the max bitrate.
+    // Having a buffer allows us to increase our quality as we are able to pre-load the buffer
+    // with additional quality whenever the bitrate is not maxed.
+    params = append(params, "-bufsize", strconv.Itoa(maxBitrate * 2))
+    params = append(params, "-map", "0:a")
+    params = append(params, "-c:a", "copy")
+    params = append(params, "-movflags", "+faststart")
+    params = append(params, "-f", "mp4")
+    params = append(params, "-y")
+    params = append(params, v.Path() + ".tmp.pt" + strconv.Itoa(count))
+    //PrintFfmpeg(params)
+    //fmt.Println("Executing...")
+    err := exec.Command("ffmpeg", params...).Run()
+    if err != nil {
+        fmt.Println(err)
+    }
+    err = Move(v.Path() + ".tmp.pt" + strconv.Itoa(count), v.Path() + ".pt" + strconv.Itoa(count))
+    if err != nil {
+        fmt.Println(err)
+    }
 }

--- a/cmd/client/utils.go
+++ b/cmd/client/utils.go
@@ -1,11 +1,62 @@
 package main
 
 import (
+    "io/ioutil"
     "os/exec"
     "os"
     "fmt"
     "strings"
+    "bufio"
+    "runtime"
+    "path/filepath"
 )
+
+func GetBrand() string {
+    return "Armchair"
+}
+
+// DefaultMetadataDir returns the default data directory of armchair. The values for
+// supported operating systems are:
+//
+// Linux:   $HOME/.armchair
+// MacOS:   $HOME/Library/Application Support/Armchair
+// Windows: %LOCALAPPDATA%\Armchair
+//
+// Might need to use "github.com/mitchellh/go-homedir" to get the home directory
+func DefaultMetadataDir() string {
+    path := ""
+    switch runtime.GOOS {
+        case "windows":
+            path = filepath.Join(os.Getenv("LOCALAPPDATA"), GetBrand())
+        case "darwin":
+            path = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", GetBrand())
+        default:
+            path = filepath.Join(os.Getenv("HOME"), "." + strings.ToLower(GetBrand()))
+    }
+    if path != "" && !PathExists(path) {
+        path = Mkdir(path)
+    }
+    return path
+}
+
+func PathExists(path string) bool {
+    if _, err := os.Stat(path); err == nil {
+        return true
+    }
+    return false
+}
+
+func PrintFfprobe(params []string) {
+    fmt.Print("ffprobe")
+    for i, param := range params {
+        if strings.HasPrefix(param, "-") || i + 1 == len(params) {
+            fmt.Print("\n  " + param)
+        } else {
+            fmt.Print(" " + param)
+        }
+    }
+    fmt.Println("")
+}
 
 func PrintFfmpeg(params []string) {
     fmt.Print("ffmpeg")
@@ -46,6 +97,31 @@ func Mkdir(target string) string {
     err := os.MkdirAll(target, os.ModePerm)
     if err != nil {
         fmt.Println("Failed to make directory: %v", err)
+        return ""
     }
     return target
+}
+
+func MkTmpDir() string {
+    tmpDir, err := ioutil.TempDir(os.TempDir(), GetBrand())
+    if err != nil {
+        fmt.Println("Failed to make temporary directory: %v", err)
+        return ""
+    }
+    return tmpDir
+}
+
+func Read(target string) []string {
+    file, err := os.Open(target)
+    if err != nil {
+        fmt.Println("Failed to open file: %s", target)
+    }
+    scanner := bufio.NewScanner(file)
+    scanner.Split(bufio.ScanLines)
+    var lines []string
+    for scanner.Scan() {
+        lines = append(lines, scanner.Text())
+    }
+    file.Close()
+    return lines
 }

--- a/cmd/client/video.go
+++ b/cmd/client/video.go
@@ -18,7 +18,7 @@ type Video struct {
     dar            *float64
     sar            *float64
     crop           *Crop
-    duration       *int
+    duration       string
     fps            string
     progressive    *bool
 }
@@ -164,6 +164,10 @@ func (v *Video) Sar() float64 {
     return *v.sar
 }
 
+func (v *Video) DetectCrop() {
+    v.Crop()
+}
+
 func (v *Video) Crop() *Crop {
 	if v.crop != nil {
 		return v.crop
@@ -179,9 +183,9 @@ func (v *Video) Crop() *Crop {
     return v.crop
 }
 
-func (v *Video) Duration() int {
-	if v.duration != nil {
-		return *v.duration
+func (v *Video) Duration() string {
+	if v.duration != "" {
+		return v.duration
 	}
 	cmd := exec.Command(
 		"ffprobe",
@@ -191,10 +195,13 @@ func (v *Video) Duration() int {
 		"-show_entries", "format=duration",
 		v.path)
 	stdout, _ := cmd.Output()
-	seconds, _ := strconv.ParseFloat(strings.TrimSuffix(string(stdout), "\n"), 64)
-	duration := int(seconds * 1000)
-	v.duration = &duration
-	return *v.duration
+	v.duration = strings.TrimSuffix(string(stdout), "\n")
+	return v.duration
+}
+
+func (v *Video) DurationMs() int {
+    seconds, _ := strconv.ParseFloat(v.Duration(), 64)
+    return int(seconds * 1000)
 }
 
 func calcFpsFromAvg(path string) string {


### PR DESCRIPTION
Use scene-detect to split the encoding of the video into multiple
processes. This will let us must multiple cores for things like
nnedi3 and av1 which are currently single thread actions.